### PR TITLE
Use config options for username to ssh to images

### DIFF
--- a/src/lib/charm/openstack/tempest.py
+++ b/src/lib/charm/openstack/tempest.py
@@ -119,8 +119,14 @@ class TempestAdminAdapter(adapters.OpenStackRelationAdapter):
             for image in glance_client.images.list():
                 if self.uconfig.get('glance-image-name') == image.name:
                     image_info['image_id'] = image.id
+                if self.uconfig.get('image-ssh-user'):
+                    image_info['image_ssh_user'] = \
+                        self.uconfig.get('image-ssh-user')
                 if self.uconfig.get('glance-alt-image-name') == image.name:
                     image_info['image_alt_id'] = image.id
+                if self.uconfig.get('image-alt-ssh-user'):
+                    image_info['image_alt_ssh_user'] = \
+                        self.uconfig.get('image-alt-ssh-user')
         except:
             hookenv.log("Glance is not ready, deferring glance query")
         return image_info

--- a/src/templates/tempest.conf
+++ b/src/templates/tempest.conf
@@ -20,8 +20,8 @@ cli_dir=/usr/local/bin
 [compute]
 flavor_ref={{ identity_admin.compute_info.flavor_id }}
 flavor_ref_alt={{ identity_admin.compute_info.flavor_alt_id }}
-image_ssh_user=cirros
-image_alt_ssh_user=ubuntu
+image_ssh_user={{ identity_admin.image_info.image_ssh_user }}
+image_alt_ssh_user={{ identity_admin.image_info.image_alt_ssh_user }}
 image_ref={{ identity_admin.image_info.image_id }}
 image_ref_alt={{ identity_admin.image_info.image_alt_id }}
 allow_tenant_isolation = true


### PR DESCRIPTION
The charm already provided the configurable options image-ssh-user
and image-alt-ssh-user, but they were not being used (instead,
default values were hardcoded in the template). This patch renders
the template with the actual configured values for the charm.

Change-Id: I96c933696483e82b29d7b68da40a7df0685ff932